### PR TITLE
Quickicon Link

### DIFF
--- a/plugins/quickicon/autoupdate/src/Extension/Autoupdate.php
+++ b/plugins/quickicon/autoupdate/src/Extension/Autoupdate.php
@@ -127,7 +127,7 @@ class Autoupdate extends CMSPlugin implements SubscriberInterface
 
         $result[] = [
             [
-                'link'  => 'index.php?option=com_config&view=component&component=com_joomlaupdate',
+                'link'  => 'index.php?option=com_config&view=component&component=com_joomlaupdate#automated-updates',
                 'image' => 'icon-health',
                 'icon'  => '',
                 'text'  => Text::_('PLG_QUICKICON_AUTOUPDATE_CHECKING'),


### PR DESCRIPTION
### Summary of Changes
This small PR ensures that the link on the quickicon goes directly to the automated updates tab of the joomla update component options


### Testing Instructions
Click on the quickicon for Automated Updates


### Actual result BEFORE applying this Pull Request
The tab that opens is either the first tab "Update Source" or the last tab you had opened 


### Expected result AFTER applying this Pull Request
The Automated Updates tab is always opened by the link


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
