### PR TITLE
Update plg_quickicon_autoupdate.ini

### DIFF
--- a/administrator/language/en-GB/plg_quickicon_autoupdate.ini
+++ b/administrator/language/en-GB/plg_quickicon_autoupdate.ini
@@ -9,7 +9,6 @@ PLG_QUICKICON_AUTOUPDATE_DISABLED="Automated Updates are disabled."
 PLG_QUICKICON_AUTOUPDATE_ERROR="Unknown Health status &hellip;"
 PLG_QUICKICON_AUTOUPDATE_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_AUTOUPDATE_GROUP_LABEL="Group"
-PLG_QUICKICON_AUTOUPDATE_OK="Automated Updates working."
+PLG_QUICKICON_AUTOUPDATE_OK="Automated Updates are enabled."
 PLG_QUICKICON_AUTOUPDATE_OUTDATED="Automated Updates connection broken."
 PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Checks the health status of automated updates and notifies you when you visit the Home Dashboard page."
-


### PR DESCRIPTION
I understand why the string "working" was chosen but I think it is better to simply say "enabled"

we know it is working as there are multiple different messages to show there is a problem (Unknown, disabled and outdated)

IT would be more consistent with the rest of Joomla to say enabled AND someone might think that working = joomla update in progress