### PR TITLE
automated_updates_email

### DIFF
--- a/administrator/components/com_joomlaupdate/config.xml
+++ b/administrator/components/com_joomlaupdate/config.xml
@@ -123,7 +123,7 @@
 			type="text"
 			label="COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_UPDATE_EMAIL_LABEL"
 			description="COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_UPDATE_EMAIL_DESCRIPTION"
-			showon="autoupdate:1"
+			showon="updatesource:default[AND]minimum_stability:4[AND]autoupdate:1"
 		/>
 	</fieldset>
 </config>


### PR DESCRIPTION
All the fields except for the admin email are hidden when the update source is not default and level is stable. 

I am assuming it is an oversight that the admin email field was not hidden

![image](https://github.com/user-attachments/assets/06024134-6512-44bf-91e6-f233d6d17a4d)
