### PR TITLE
Update com_joomlaupdate.ini

### DIFF
--- a/administrator/language/en-GB/com_joomlaupdate.ini
+++ b/administrator/language/en-GB/com_joomlaupdate.ini
@@ -9,7 +9,7 @@ COM_JOOMLAUPDATE_AUTOUPDATE_UNREGISTER_ERROR="Error while unregistering from aut
 COM_JOOMLAUPDATE_AUTOUPDATE_UNREGISTER_SUCCESS="Unregistered from autoupdate service."
 COM_JOOMLAUPDATE_CAPTIVE_HEADLINE="Confirm your credentials"
 COM_JOOMLAUPDATE_CHECKED_UPDATES="Checked for updates."
-COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_DISABLED_LABEL="<span class=\"fa-fw me-2 fa fa-info-circle\"></span> Automated updates are only supported for the \"default\" channel and \"Minimum Stability\" \"Stable\"."
+COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_DISABLED_LABEL="<span class=\"fa-fw me-2 fa fa-info-circle\"></span>Automated updates are only supported for the \"default\" channel and \"Minimum Stability\" \"Stable\"."
 COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_LABEL="Automated Updates"
 COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_DESC="Automatically update Joomla to the latest version when it is available."
 COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_LABEL="Automated Update"


### PR DESCRIPTION
space should not be used in a language string for padding. And its not needed anyway as the icon already has me-2 class which is sufficient
